### PR TITLE
Remove create date from RSPV's group section

### DIFF
--- a/Meetup.NetStandard.Tests/RsvpTests.cs
+++ b/Meetup.NetStandard.Tests/RsvpTests.cs
@@ -54,6 +54,7 @@ namespace Meetup.NetStandard.Tests
             var rsvpData = response.Data.First();
             Assert.Equal("yes",rsvpData.Response);
             Assert.Equal("coorganizer", rsvpData.Member.Role);
+            Assert.Equal(460984584, rsvpData.Group.GroupPhoto.Id);
         }
 
 

--- a/Meetup.NetStandard/Response/MeetupGroup.cs
+++ b/Meetup.NetStandard/Response/MeetupGroup.cs
@@ -6,19 +6,10 @@ using Newtonsoft.Json.Converters;
 
 namespace Meetup.NetStandard.Response
 {
-    public class MeetupGroup
+    public class MeetupGroup:MeetupGroupBase
     {
         [JsonProperty("created"), JsonConverter(typeof(MillisecondUnixDateTimeConverter))]
         public DateTime Created { get; set; }
-
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("id")]
-        public int Id { get; set; }
-
-        [JsonProperty("join_mode")]
-        public JoinMode JoinMode { get; set; }
 
         [JsonProperty("lat")]
         public double Latitude { get; set; }
@@ -26,22 +17,10 @@ namespace Meetup.NetStandard.Response
         [JsonProperty("lon")]
         public double Longitude { get; set; }
 
-        [JsonProperty("urlname")]
-        public string UrlName { get; set; }
-
-        [JsonProperty("who")]
-        public string Who { get; set; }
-
-        [JsonProperty("localized_location")]
-        public string LocalizedLocation { get; set; }
-
         [JsonProperty("region")]
         public string Region { get; set; }
 
         [JsonProperty("timezone")]
         public string TimeZone { get; set; }
-
-        [JsonExtensionData]
-        public Dictionary<string,object> ExtraFields { get; set; } 
     }
 }

--- a/Meetup.NetStandard/Response/MeetupGroupBase.cs
+++ b/Meetup.NetStandard/Response/MeetupGroupBase.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Meetup.NetStandard.Response
+{
+    public class MeetupGroupBase
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("join_mode")]
+        public JoinMode JoinMode { get; set; }
+
+        [JsonProperty("urlname")]
+        public string UrlName { get; set; }
+
+        [JsonProperty("who")]
+        public string Who { get; set; }
+
+        [JsonProperty("localized_location")]
+        public string LocalizedLocation { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string,object> ExtraFields { get; set; } 
+    }
+}

--- a/Meetup.NetStandard/Response/MeetupMember.cs
+++ b/Meetup.NetStandard/Response/MeetupMember.cs
@@ -14,6 +14,6 @@ namespace Meetup.NetStandard.Response
         public string Name { get; set; }
 
         [JsonProperty("photo")]
-        public MeetupPhoto Time { get; set; }
+        public MeetupPhoto Photo { get; set; }
     }
 }

--- a/Meetup.NetStandard/Response/Rsvps/RsvpGroup.cs
+++ b/Meetup.NetStandard/Response/Rsvps/RsvpGroup.cs
@@ -1,10 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Newtonsoft.Json;
 
 namespace Meetup.NetStandard.Response.Rsvps
 {
-    public class RsvpGroup:MeetupGroup
+    public class RsvpGroup:MeetupGroupBase
     {
+        [JsonProperty("members")]
+        public int Members { get; set; }
+
+        [JsonProperty("group_photo")]
+        public MeetupPhoto GroupPhoto { get; set; }
     }
 }


### PR DESCRIPTION
The Meetup response for getting RSVP's has group section but that group section doesn't include a create date.  This resulted in a date of in the year 0001.  I refactored the group response objects to remove the create date from the RSVP's response object group section.